### PR TITLE
reassign_replicator + fix non-zipped package precheck

### DIFF
--- a/src/actions.jl
+++ b/src/actions.jl
@@ -525,6 +525,76 @@ function assign_replicators(paperID, selection)
 end
 
 
+"""
+    reassign_replicator(paperID)
+
+Reassign the current round's replicator(s) for `paperID` to someone else —
+e.g. the original replicator became unavailable and their Dropbox download
+link expired. Unlike `assign`/`assign_replicators`, this does NOT require the
+paper to be in `author_back_de` status: it operates on a paper already
+`with_replicator`, regenerates the package download link (this transparently
+handles an expired link), overwrites `replicator1`/`replicator2` for the
+current round, and sends a fresh assignment email to the newly selected
+replicator(s) only. The old replicator is not notified. The paper's `status`
+is left unchanged.
+"""
+function reassign_replicator(paperID)
+    paper_row_df = db_filter_paper(paperID)
+    nrow(paper_row_df) == 1 || error("Paper ID $paperID not found or has multiple entries")
+    paper_row = paper_row_df[1, :]
+    current_status = paper_row.status
+
+    # Interactively pick new replicator(s) for the current round
+    selection = select_replicators(paperID)
+
+    old_iter = db_filter_iteration(paperID, selection.current_round)
+    nrow(old_iter) == 1 || error("No iteration found for $paperID round $(selection.current_round)")
+    old_replicator1 = old_iter[1, :replicator1]
+    old_replicator2 = old_iter[1, :replicator2]
+
+    # Regenerate the package download link (also fixes an expired one)
+    download_url = dbox_link_at_path(selection.current_iteration.file_request_path, dbox_token)
+    repo_url = selection.current_iteration.github_url
+    caseID = case_id(paper_row.journal, paper_row.surname_of_author, paperID, selection.current_round)
+
+    # Reuse the status-transition machinery as a no-op transaction wrapper
+    # (from_status == to_status == current_status), so we get the same
+    # transactional guarantees as assign_replicators without touching status.
+    result = update_paper_status(paperID, current_status, current_status) do con
+        if !isnothing(selection.secondary_email)
+            gmail_assign(selection.primary_name, selection.primary_email, caseID, download_url, repo_url,
+                        first2=selection.secondary_name, email2=selection.secondary_email, back=true)
+        else
+            gmail_assign(selection.primary_name, selection.primary_email, caseID, download_url, repo_url, back=true)
+        end
+
+        DBInterface.execute(con, """
+        UPDATE iterations
+        SET replicator1 = ?, date_assigned_repl = ?
+        WHERE paper_id = ? AND round = ?
+        """, (selection.primary_email, today(), paperID, selection.current_round))
+
+        # Always overwrite replicator2 (including clearing it to NULL if no
+        # secondary was picked this time), so a stale prior secondary doesn't linger.
+        DBInterface.execute(con, """
+        UPDATE iterations
+        SET replicator2 = ?
+        WHERE paper_id = ? AND round = ?
+        """, (selection.secondary_email, paperID, selection.current_round))
+
+        return (primary=selection.primary_email, secondary=selection.secondary_email)
+    end
+
+    println("✅ Reassigned paper $(paperID) round $(selection.current_round)")
+    old_str = ismissing(old_replicator2) || isnothing(old_replicator2) ? "$(old_replicator1)" : "$(old_replicator1), $(old_replicator2)"
+    new_str = isnothing(result.secondary) ? "$(result.primary)" : "$(result.primary), $(result.secondary)"
+    println("   old: $(old_str)")
+    println("   new: $(new_str)")
+    println()
+
+    return result
+end
+
 function _show_dropbox_password_for_assignment(paperID, round, primary_email)
     iter = db_filter_iteration(paperID, round)
     if nrow(iter) == 0

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -928,13 +928,13 @@ function de_make_decision(paperID, decision)
     end
     
     r = NamedTuple(paper[1, :])
-    
-    # Validate current status
-    if !any(occursin.(r.status, ["replicator_back_de","author_back_de"]))
+
+    # Validate current status (revise reuses prepare_rnrs, which enforces its own status gate)
+    if decision == "revise" && r.status != "replicator_back_de" && r.status != "author_back_de"
         error("Paper must be in either 'replicator_back_de' or 'author_back_de' status to process a decision")
     end
-    
-    
+
+
     # Process based on decision
     if decision == "accept"
         update_paper_status(paperID, r.status, "acceptable_package") do con

--- a/src/gmailing.jl
+++ b/src/gmailing.jl
@@ -411,7 +411,7 @@ function gmail_rnr_body(first,paperID,title,url)
 end
 
 
-function gmail_file_request(name,paperID,title,url,email1;email2 = nothing, JO = false)
+function gmail_file_request(name,paperID,title,url,email1;email2 = nothing, JO = false, paper_url = nothing)
     if JO
         body = gmail_file_request_JO_body(name,paperID,title,url)
     gmail_send(
@@ -423,7 +423,7 @@ function gmail_file_request(name,paperID,title,url,email1;email2 = nothing, JO =
 
     else
         to = isnothing(email2) ? [author_email(email1)] : [author_email(email1), author_email(email2)]
-        body = gmail_file_request_body(name,paperID,title,url)
+        body = gmail_file_request_body(name,paperID,title,url,paper_url)
         gmail_send(
             to,
             "JPE Replication Package $paperID Upload Request",
@@ -478,8 +478,8 @@ function gmail_file_request_JO_body(authorlast,paperID,title,url)
     string(m1,signature())
 end
 
-function gmail_file_request_body(first,paperID,title,url)
-    @debug first paperID title url
+function gmail_file_request_body(first,paperID,title,url,paper_url = nothing)
+    @debug first paperID title url paper_url
 
     m1 = """
     Dear $first,
@@ -496,6 +496,13 @@ function gmail_file_request_body(first,paperID,title,url)
     Please review the required contents of your replication package described at https://jpedataeditor.github.io/ .
     <br>
     <br>
+    $(isnothing(paper_url) ? "" : """
+    Please use the following dropbox upload link to also share the latest version of your paper (both in pdf and latex format, if applicable). Please let me know if there are any changes between that version and what was conditionally accepted by your handling editor:
+    <br>
+    $paper_url
+    <br>
+    <br>
+    """)
     It is our policy to ask for the submission of your replication package within 30 days, i.e., by $(Dates.format(today() + Day(30), dateformat"d U Y")). If you foresee a problem with meeting this deadline, you will need to request an extension. 
     <br>
     <br>

--- a/src/google.jl
+++ b/src/google.jl
@@ -252,7 +252,7 @@ function google_arrivals()
         println("notify author and JO for $(r.paper_slug)?")
         yes_no_menu = RadioMenu(["Yes","No"])  # Default is first option 
         if request(yes_no_menu) == 1
-            gmail_file_request(r.firstname_of_author, r.paper_id, r.title, r.file_request_url_pkg, author_email(r.email_of_author), email2 = ismissing(r.email_of_second_author) ? nothing : author_email(r.email_of_second_author))
+            gmail_file_request(r.firstname_of_author, r.paper_id, r.title, r.file_request_url_pkg, author_email(r.email_of_author), email2 = ismissing(r.email_of_second_author) ? nothing : author_email(r.email_of_second_author), paper_url = r.file_request_url_paper)
 
             r.date_with_authors = Dates.today()
 

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -309,23 +309,31 @@ function write_runner_script(repoloc::String, no_data_scan::Vector{String}; run_
                 isfile(f) && endswith(lowercase(f), ".zip")
             end
 
-            if isempty(candidates)
-                error("No ZIP file found inside Dropbox folder archive")
-            end
-
-            @info "Found \$(length(candidates)) ZIP(s) to extract" candidates
             isdir(dest_path) && rm(dest_path; recursive=true, force=true)
             mkpath(dest_path)
 
-            for pkg_zip in candidates
-                @info "Unzipping \$pkg_zip..."
-                try
-                    run(`unzip -oq \$pkg_zip -d \$dest_path`)
-                    if isdir(dest_path)
-                        rm_git(dest_path)
+            if isempty(candidates)
+                # No nested ZIP — the author's Dropbox folder contained the
+                # replication package's files/subfolders directly (not a .zip),
+                # so the extracted tmp_dir already *is* the package.
+                @info "No nested ZIP found — using extracted folder contents directly as the package"
+                for f in readdir(tmp_dir; join=true)
+                    cp(f, joinpath(dest_path, basename(f)); force=true)
+                end
+                rm_git(dest_path)
+            else
+                @info "Found \$(length(candidates)) ZIP(s) to extract" candidates
+
+                for pkg_zip in candidates
+                    @info "Unzipping \$pkg_zip..."
+                    try
+                        run(`unzip -oq \$pkg_zip -d \$dest_path`)
+                        if isdir(dest_path)
+                            rm_git(dest_path)
+                        end
+                    catch e
+                        @warn "unzip of \$pkg_zip exited non-zero" exception=e
                     end
-                catch e
-                    @warn "unzip of \$pkg_zip exited non-zero" exception=e
                 end
             end
 

--- a/test/test_gmailing.jl
+++ b/test/test_gmailing.jl
@@ -18,3 +18,31 @@
     @test occursin("remote-protocol.html", body)
 
 end
+
+@testset "gmail_file_request_body" begin
+
+    body_no_paper = JPE.gmail_file_request_body(
+        "Jane",
+        "TEST-CASEID",
+        "A Great Paper",
+        "https://dropbox.com/request/pkg"
+    )
+
+    @test occursin("Jane", body_no_paper)
+    @test occursin("TEST-CASEID", body_no_paper)
+    @test occursin("https://dropbox.com/request/pkg", body_no_paper)
+    @test !occursin("also share the latest version", body_no_paper)
+
+    body_with_paper = JPE.gmail_file_request_body(
+        "Jane",
+        "TEST-CASEID",
+        "A Great Paper",
+        "https://dropbox.com/request/pkg",
+        "https://dropbox.com/request/paper"
+    )
+
+    @test occursin("https://dropbox.com/request/pkg", body_with_paper)
+    @test occursin("https://dropbox.com/request/paper", body_with_paper)
+    @test occursin("also share the latest version", body_with_paper)
+
+end


### PR DESCRIPTION
## Summary
- `reassign_replicator(paperID)`: swap the current round's replicator(s) without requiring the `author_back_de` status gate. Regenerates the (possibly expired) download link, overwrites `replicator1`/`replicator2`, emails only the new replicator(s).
- Fix `write_runner_script`'s precheck: when a Dropbox package folder holds files directly (no nested `.zip`), use the extracted contents as the package instead of erroring "No ZIP file found inside Dropbox folder archive" (hit on JPE-Rivera-20251367 run).

## Test plan
- [x] `Pkg.test("JPE")` — 46/46 pass
- [ ] Verify `reassign_replicator` against a live paper (interactive menu)
- [ ] Re-run precheck on JPE-Rivera-20251367 to confirm fix